### PR TITLE
chore: create `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# all text files except SVG is detectable, this is not a codebase
+* linguist-detectable=true
+*.svg linguist-detectable=false
+


### PR DESCRIPTION
这个项目主要是文档，而 Markdown 文件被默认排除在代码量统计之外，添加这个文件将把所有文本文件（SVG 除外）包含在统计内，以更合理地反映这个项目的真实规模。

参考我自己的 portfolio 仓库：https://github.com/sghuang19/portfolio