### PR TITLE
feat: use history routerMode to remove # in URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,7 @@
   <script src="//cdn.jsdelivr.net/npm/docsify-edit-on-github"></script>
   <script>
     window.$docsify = {
+      routerMode: 'history',  // removes the # in URL
       alias: {
         '.*?/awesome': 'https://raw.githubusercontent.com/docsifyjs/awesome-docsify/master/README.md',
         '.*?/changelog': 'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG.md',


### PR DESCRIPTION
这个修改移除了 URL 里的井号，在本地测试没有问题，请确认能否正常部署！