### PR TITLE
Html2canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@primeuix/themes": "^1.0.0",
+    "@primeuix/themes": "^1.0.3",
     "primevue": "^4.3.3"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/ajv": "^1.0.4",
-    "@types/node": "^22.13.14",
+    "@types/node": "^22.14.1",
     "@vue/tsconfig": "^0.7.0",
     "ajv": "^8.17.1",
-    "cspell": "^8.18.0",
-    "eslint": "^9.23.0",
-    "eslint-config-prettier": "^10.1.1",
+    "cspell": "^8.18.1",
+    "eslint": "^9.24.0",
+    "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-vue": "^10.0.0",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
@@ -37,12 +37,12 @@
     "markdown-it-task-lists": "^2.1.1",
     "markdownlint-cli2": "^0.17.2",
     "prettier": "^3.5.3",
-    "prettier-plugin-sh": "^0.17.0",
-    "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3",
+    "prettier-plugin-sh": "^0.17.2",
+    "typescript-eslint": "^8.29.1",
+    "vite": "^6.2.6",
     "vitepress": "^1.6.3",
-    "vitest": "^3.0.9",
-    "yaml": "^2.7.0",
+    "vitest": "^3.1.1",
+    "yaml": "^2.7.1",
     "zod": "^3.24.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "dependencies": {
     "@primeuix/themes": "^1.0.3",
-    "primevue": "^4.3.3"
+    "dom-to-image-more": "^3.5.0",
+    "primevue": "^4.3.3",
+    "qrcodejs2": "^0.0.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",

--- a/src/.vitepress/theme/index.ts
+++ b/src/.vitepress/theme/index.ts
@@ -5,11 +5,14 @@ import DefaultTheme from "vitepress/theme";
 import Aura from "@primeuix/themes/aura";
 import PrimeVue from "primevue/config";
 
+import Layout from "../../components/Layout.vue";
 import PostList from "../../components/PostList.vue";
+import SelectionShareMenu from "../../components/SelectionShareMenu.vue";
 import "./style.css";
 
 export default {
   extends: DefaultTheme,
+  Layout,
   enhanceApp({ app, router }) {
     /* redirect legacy hash path, can only be done on client side */
     router.onAfterRouteChange = async (to) => {
@@ -25,5 +28,6 @@ export default {
 
     /* register global components */
     app.component("PostList", PostList);
+    app.component("SelectionShareMenu", SelectionShareMenu);
   },
 } satisfies Theme;

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { useData } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
+import SelectionShareMenu from './SelectionShareMenu.vue'
+
+const { Layout } = DefaultTheme
+</script>
+
+<template>
+  <Layout>
+    <template #layout-bottom>
+      <SelectionShareMenu />
+    </template>
+  </Layout>
+</template>

--- a/src/components/SelectionShareMenu.vue
+++ b/src/components/SelectionShareMenu.vue
@@ -1,0 +1,184 @@
+<script setup>
+import { onMounted, onUnmounted, ref } from "vue";
+
+import ShareCard from "./ShareCard.vue";
+
+const menuVisible = ref(false);
+const menuPosition = ref({ x: 0, y: 0 });
+const selectedText = ref("");
+const shareCardVisible = ref(false);
+
+// Function to show the menu
+const showMenu = (x, y, text) => {
+  if (text && text.trim() !== "") {
+    selectedText.value = text;
+    menuPosition.value = { x, y };
+    menuVisible.value = true;
+  }
+};
+
+// Function to hide the menu
+const hideMenu = () => {
+  menuVisible.value = false;
+};
+
+// Handle text selection
+const handleSelection = () => {
+  if (typeof window === "undefined") return;
+
+  const selection = window.getSelection();
+  if (selection && selection.toString().trim() !== "") {
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+
+    // Position the menu above the selection
+    const x = rect.left + rect.width / 2;
+    const y = rect.top - 10; // Position above the selection
+
+    showMenu(x, y, selection.toString());
+  }
+};
+
+// Handle mouseup event to detect selection
+const handleMouseUp = () => {
+  if (typeof window === "undefined") return;
+  setTimeout(handleSelection, 10); // Small delay to ensure selection is complete
+};
+
+// Copy selected text to clipboard
+const copyText = async () => {
+  if (typeof navigator === "undefined") return;
+
+  try {
+    await navigator.clipboard.writeText(selectedText.value);
+    // Use a non-blocking notification instead of alert
+    console.log("文本已复制到剪贴板");
+    hideMenu();
+  } catch (err) {
+    console.error("复制失败:", err);
+  }
+};
+
+// Share selected text
+const shareText = () => {
+  // Show share card in the current page
+  shareCardVisible.value = true;
+  hideMenu();
+};
+
+// Close share card
+const closeShareCard = () => {
+  shareCardVisible.value = false;
+};
+
+// Click outside to hide menu
+const handleClickOutside = (event) => {
+  if (menuVisible.value && !event.target.closest(".selection-menu")) {
+    hideMenu();
+  }
+};
+
+onMounted(() => {
+  if (typeof document === "undefined") return;
+
+  document.addEventListener("mouseup", handleMouseUp);
+  document.addEventListener("mousedown", handleClickOutside);
+});
+
+onUnmounted(() => {
+  if (typeof document === "undefined") return;
+
+  document.removeEventListener("mouseup", handleMouseUp);
+  document.removeEventListener("mousedown", handleClickOutside);
+});
+</script>
+
+<template>
+  <div>
+    <div
+      v-if="menuVisible"
+      class="selection-menu"
+      :style="{
+        left: `${menuPosition.x}px`,
+        top: `${menuPosition.y}px`,
+        transform: 'translate(-50%, -100%)',
+      }"
+    >
+      <button @click="copyText" class="menu-button copy-button" title="复制">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path
+            d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+          ></path>
+        </svg>
+      </button>
+      <button @click="shareText" class="menu-button share-button" title="分享">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="18" cy="5" r="3"></circle>
+          <circle cx="6" cy="12" r="3"></circle>
+          <circle cx="18" cy="19" r="3"></circle>
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Share Card Component -->
+    <ShareCard
+      :text="selectedText"
+      :visible="shareCardVisible"
+      :on-close="closeShareCard"
+    />
+  </div>
+</template>
+
+<style scoped>
+.selection-menu {
+  position: fixed;
+  display: flex;
+  background-color: #333;
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  padding: 8px;
+}
+
+.menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin: 0 4px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: transparent;
+  color: white;
+  transition: background-color 0.2s;
+}
+
+.menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+</style>

--- a/src/components/SelectionShareMenu.vue
+++ b/src/components/SelectionShareMenu.vue
@@ -41,7 +41,8 @@ const handleSelection = () => {
 
 // Handle mouseup event to detect selection
 const handleMouseUp = () => {
-  if (typeof window === "undefined") return;
+  // 如果分享卡片已显示，不再监听选择变化
+  if (typeof window === "undefined" || shareCardVisible.value) return;
   setTimeout(handleSelection, 10); // Small delay to ensure selection is complete
 };
 
@@ -69,6 +70,12 @@ const shareText = () => {
 // Close share card
 const closeShareCard = () => {
   shareCardVisible.value = false;
+  // 清空选中的文本，以便用户可以重新选择
+  setTimeout(() => {
+    if (typeof window !== "undefined") {
+      window.getSelection()?.removeAllRanges();
+    }
+  }, 100);
 };
 
 // Click outside to hide menu

--- a/src/components/SelectionShareMenu.vue
+++ b/src/components/SelectionShareMenu.vue
@@ -161,7 +161,7 @@ onUnmounted(() => {
     <ShareCard
       :text="selectedText"
       :visible="shareCardVisible"
-      :on-close="closeShareCard"
+      @close="closeShareCard"
     />
   </div>
 </template>

--- a/src/components/SelectionShareMenu.vue
+++ b/src/components/SelectionShareMenu.vue
@@ -35,7 +35,14 @@ const handleSelection = () => {
     const x = rect.left + rect.width / 2;
     const y = rect.top - 10; // Position above the selection
 
-    showMenu(x, y, selection.toString());
+    // 获取选中文本的HTML内容
+    const container = document.createElement("div");
+    const clonedSelection = range.cloneContents();
+    container.appendChild(clonedSelection);
+    const htmlContent = container.innerHTML;
+
+    // 使用HTML内容而不是纯文本
+    showMenu(x, y, htmlContent);
   }
 };
 

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -77,9 +77,9 @@ const generateQRCode = () => {
 
     // 创建图片元素
     const qrCodeImg = document.createElement("img");
-    qrCodeImg.alt = "扫描二维码访问原文";
-    qrCodeImg.style.width = "128px";
-    qrCodeImg.style.height = "128px";
+    qrCodeImg.alt = "扫码访问";
+    qrCodeImg.style.width = "80px";
+    qrCodeImg.style.height = "80px";
 
     // 处理主题颜色
     let bgColor = theme.background.replace("#", "");
@@ -90,7 +90,7 @@ const generateQRCode = () => {
     if (!fgColor) fgColor = "000000";
 
     // 使用QR Code API生成二维码
-    const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=128x128&data=${encodeURIComponent(qrUrl)}&bgcolor=${bgColor}&color=${fgColor}`;
+    const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=${encodeURIComponent(qrUrl)}&bgcolor=${bgColor}&color=${fgColor}`;
 
     // 设置加载事件
     qrCodeImg.onload = () => {
@@ -100,7 +100,7 @@ const generateQRCode = () => {
     qrCodeImg.onerror = (e) => {
       console.error("Failed to load QR code image:", e);
       // 尝试使用默认颜色
-      qrCodeImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=128x128&data=${encodeURIComponent(qrUrl)}`;
+      qrCodeImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=${encodeURIComponent(qrUrl)}`;
     };
 
     // 设置图片源
@@ -248,20 +248,23 @@ onMounted(() => {
               v-html="text"
               class="formatted-text"
             ></blockquote>
-            <div class="share-source">
-              <p>南方科技大学飞跃手册</p>
-            </div>
           </div>
-          <div class="share-qrcode-container">
-            <div
-              class="share-qrcode"
-              :style="{
-                backgroundColor: themeStyle.background,
-                borderColor: themeStyle.borderColor,
-              }"
-            >
-              <div id="qrcode"></div>
-              <p class="qrcode-text">扫描二维码访问原文</p>
+          <div class="share-footer">
+            <div class="share-footer-left">
+              <p class="share-website">南科飞跃手册</p>
+              <p class="share-url">sustech-application.com</p>
+            </div>
+            <div class="share-qrcode-container">
+              <div
+                class="share-qrcode"
+                :style="{
+                  backgroundColor: themeStyle.background,
+                  borderColor: themeStyle.borderColor,
+                }"
+              >
+                <div id="qrcode"></div>
+                <p class="qrcode-text">扫码访问</p>
+              </div>
             </div>
           </div>
         </div>
@@ -372,33 +375,61 @@ onMounted(() => {
   font-size: 14px;
 }
 
+.share-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding-top: 15px;
+}
+
+.share-footer-left {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.share-website {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0 0 5px 0;
+}
+
+.share-url {
+  font-size: 14px;
+  opacity: 0.8;
+  margin: 0;
+}
+
 .share-qrcode-container {
   display: flex;
-  justify-content: center;
-  margin-top: 20px;
+  justify-content: flex-end;
 }
 
 .share-qrcode {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 15px;
+  padding: 8px;
   border-radius: 8px;
   border: 1px solid;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  max-width: 160px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  max-width: 100px;
 }
 
 .share-qrcode img {
   display: block;
   border-radius: 4px;
+  width: 80px;
+  height: 80px;
 }
 
 .qrcode-text {
-  margin-top: 10px;
-  font-size: 14px;
+  margin-top: 5px;
+  font-size: 12px;
   text-align: center;
-  line-height: 1.4;
+  line-height: 1.2;
 }
 
 /* 控制按钮样式 */

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, defineEmits, defineProps, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const props = defineProps({
   text: {
@@ -77,7 +77,7 @@ const generateQRCode = () => {
 
     // 创建图片元素
     const qrCodeImg = document.createElement("img");
-    qrCodeImg.alt = "扫码访问";
+    qrCodeImg.alt = "扫码访问原文";
     qrCodeImg.style.width = "80px";
     qrCodeImg.style.height = "80px";
 
@@ -263,7 +263,7 @@ onMounted(() => {
                 }"
               >
                 <div id="qrcode"></div>
-                <p class="qrcode-text">扫码访问</p>
+                <p class="qrcode-text">扫码访问原文</p>
               </div>
             </div>
           </div>

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -25,7 +25,8 @@ const themes = [
   { name: "light", background: "#fff", text: "#333", border: "#4285f4" },
   { name: "blue", background: "#1a73e8", text: "#fff", border: "#fff" },
   { name: "green", background: "#0f9d58", text: "#fff", border: "#fff" },
-  { name: "red", background: "#ea4335", text: "#fff", border: "#fff" },
+  { name: "orange", background: "#ed6c00", text: "#ffffff", border: "#ffffff" },
+  { name: "teal", background: "#2bb7b3", text: "#ffffff", border: "#ffffff" },
 ];
 
 // 当前主题的样式

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -101,6 +101,12 @@ const downloadAsImage = async () => {
     // 克隆分享卡片
     const clone = shareCardRef.value.cloneNode(true);
 
+    // 确保 HTML 格式在克隆中保留
+    const blockquote = clone.querySelector(".formatted-text");
+    if (blockquote) {
+      blockquote.innerHTML = props.text;
+    }
+
     // 确保背景色正确应用
     const theme =
       themes.find((t) => t.name === currentTheme.value) || themes[0];
@@ -184,9 +190,11 @@ onMounted(() => {
       >
         <div class="share-content">
           <div class="share-text">
-            <blockquote :style="{ borderLeftColor: themeStyle.borderColor }">
-              {{ text }}
-            </blockquote>
+            <blockquote
+              :style="{ borderLeftColor: themeStyle.borderColor }"
+              v-html="text"
+              class="formatted-text"
+            ></blockquote>
             <div class="share-source">
               <p>来源: 南方科技大学飞跃手册</p>
             </div>
@@ -386,5 +394,42 @@ onMounted(() => {
   .theme-selector {
     justify-content: center;
   }
+}
+
+.formatted-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.formatted-text p {
+  margin: 0.5em 0;
+}
+
+.formatted-text strong,
+.formatted-text b {
+  font-weight: bold;
+}
+
+.formatted-text em,
+.formatted-text i {
+  font-style: italic;
+}
+
+.formatted-text a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.formatted-text ul,
+.formatted-text ol {
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+
+.formatted-text code {
+  font-family: monospace;
+  background-color: rgba(0, 0, 0, 0.1);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
 }
 </style>

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -91,12 +91,48 @@ const downloadAsImage = async () => {
   try {
     const domToImage = await import("dom-to-image-more");
 
-    const dataUrl = await domToImage.toPng(shareCardRef.value, {
-      quality: 0.95,
-      bgcolor: "transparent",
+    // 创建一个新的div元素，用于生成图片
+    const cloneContainer = document.createElement("div");
+    cloneContainer.style.position = "absolute";
+    cloneContainer.style.left = "-9999px";
+    cloneContainer.style.top = "-9999px";
+    document.body.appendChild(cloneContainer);
+
+    // 克隆分享卡片
+    const clone = shareCardRef.value.cloneNode(true);
+
+    // 确保背景色正确应用
+    const theme =
+      themes.find((t) => t.name === currentTheme.value) || themes[0];
+    clone.style.backgroundColor = theme.background;
+    clone.style.color = theme.text;
+    clone.style.width = `${shareCardRef.value.offsetWidth}px`;
+    clone.style.padding = "20px";
+    clone.style.borderRadius = "8px";
+    clone.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.1)";
+
+    // 添加到临时容器
+    cloneContainer.appendChild(clone);
+
+    // 使用toPng生成图片
+    const dataUrl = await domToImage.toPng(clone, {
+      quality: 1,
+      bgcolor: theme.background,
+      width: shareCardRef.value.offsetWidth,
+      height: shareCardRef.value.offsetHeight,
+      style: {
+        margin: "0",
+        padding: "20px",
+        "border-radius": "8px",
+        "background-color": theme.background,
+        color: theme.text,
+      },
     });
 
-    // Create download link
+    // 移除临时元素
+    document.body.removeChild(cloneContainer);
+
+    // 创建下载链接
     const link = document.createElement("a");
     link.download = `share-${new Date().getTime()}.png`;
     link.href = dataUrl;
@@ -143,6 +179,7 @@ onMounted(() => {
           backgroundColor: themeStyle.background,
           color: themeStyle.color,
           borderColor: themeStyle.borderColor,
+          boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
         }"
       >
         <div class="share-content">
@@ -247,6 +284,12 @@ onMounted(() => {
 }
 
 .share-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.share-text {
   flex: 1;
 }
 

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -141,9 +141,19 @@ const downloadAsImage = async () => {
     // 确保背景色正确应用
     const theme =
       themes.find((t) => t.name === currentTheme.value) || themes[0];
+
+    // 计算厚度分辨率的尺寸
+    const originalWidth = shareCardRef.value.offsetWidth;
+    const originalHeight = shareCardRef.value.offsetHeight;
+    const scale = 3; // 3倍分辨率
+    const scaledWidth = originalWidth * scale;
+    const scaledHeight = originalHeight * scale;
+
+    // 设置克隆元素的样式
+    clone.style.width = `${originalWidth}px`;
+    clone.style.height = `${originalHeight}px`;
     clone.style.backgroundColor = theme.background;
     clone.style.color = theme.text;
-    clone.style.width = `${shareCardRef.value.offsetWidth}px`;
     clone.style.padding = "20px";
     clone.style.borderRadius = "8px";
     clone.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.1)";
@@ -151,18 +161,20 @@ const downloadAsImage = async () => {
     // 添加到临时容器
     cloneContainer.appendChild(clone);
 
-    // 使用toPng生成图片
+    // 使用toPng生成高分辨率图片
     const dataUrl = await domToImage.toPng(clone, {
       quality: 1,
       bgcolor: theme.background,
-      width: shareCardRef.value.offsetWidth,
-      height: shareCardRef.value.offsetHeight,
+      width: scaledWidth, // 使用放大后的宽度
+      height: scaledHeight, // 使用放大后的高度
       style: {
         margin: "0",
         padding: "20px",
         "border-radius": "8px",
         "background-color": theme.background,
         color: theme.text,
+        transform: `scale(${scale})`,
+        "transform-origin": "top left",
       },
     });
 

--- a/src/components/ShareCard.vue
+++ b/src/components/ShareCard.vue
@@ -1,0 +1,244 @@
+<script setup>
+import { defineProps, onMounted, ref, watch } from "vue";
+
+const props = defineProps({
+  text: {
+    type: String,
+    required: true,
+  },
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+  "on-close": {
+    type: Function,
+    default: () => {},
+  },
+});
+
+const qrcodeGenerated = ref(false);
+const isGeneratingImage = ref(false);
+const shareCardRef = ref(null);
+
+// Function to generate QR code
+const generateQRCode = async () => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  if (!document.getElementById("qrcode") || qrcodeGenerated.value) return;
+
+  try {
+    const QRCodeModule = await import("qrcodejs2");
+    const QRCode = QRCodeModule.default;
+
+    new QRCode(document.getElementById("qrcode"), {
+      text: window.location.href,
+      width: 128,
+      height: 128,
+      colorDark: "#000000",
+      colorLight: "#ffffff",
+      correctLevel: QRCode.CorrectLevel.H,
+    });
+
+    qrcodeGenerated.value = true;
+  } catch (err) {
+    console.error("Failed to load QRCode:", err);
+  }
+};
+
+// Function to download share card as image
+const downloadAsImage = async () => {
+  if (!shareCardRef.value || typeof window === "undefined") return;
+
+  isGeneratingImage.value = true;
+
+  try {
+    const domToImage = await import("dom-to-image-more");
+
+    const dataUrl = await domToImage.toPng(shareCardRef.value, {
+      quality: 0.95,
+      bgcolor: "#fff",
+    });
+
+    // Create download link
+    const link = document.createElement("a");
+    link.download = `share-${new Date().getTime()}.png`;
+    link.href = dataUrl;
+    link.click();
+
+    isGeneratingImage.value = false;
+  } catch (err) {
+    console.error("Failed to generate image:", err);
+    isGeneratingImage.value = false;
+  }
+};
+
+// Watch for visibility changes to generate QR code when component becomes visible
+watch(
+  () => props.visible,
+  (newValue) => {
+    if (newValue && !qrcodeGenerated.value) {
+      // Small delay to ensure DOM is ready
+      setTimeout(generateQRCode, 100);
+    }
+  },
+);
+
+onMounted(() => {
+  if (props.visible) {
+    setTimeout(generateQRCode, 100);
+  }
+});
+</script>
+
+<template>
+  <div v-if="visible" class="share-card-overlay" @click="props['on-close']">
+    <div class="share-card-container" @click.stop>
+      <div class="share-card-header">
+        <h3>分享内容</h3>
+        <button class="close-button" @click="props['on-close']">×</button>
+      </div>
+      <div class="share-card" ref="shareCardRef">
+        <div class="share-content">
+          <blockquote>{{ text }}</blockquote>
+          <div class="share-source">
+            <p>来源: 南方科技大学飞跃手册</p>
+          </div>
+        </div>
+        <div class="share-qrcode">
+          <div id="qrcode"></div>
+          <p>扫描二维码访问原文</p>
+        </div>
+        <div class="share-actions">
+          <button
+            class="download-button"
+            @click="downloadAsImage"
+            :disabled="isGeneratingImage"
+          >
+            {{ isGeneratingImage ? "生成中..." : "下载分享图片" }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.share-card-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1001;
+}
+
+.share-card-container {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.share-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.share-card-header h3 {
+  margin: 0;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+}
+
+.share-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  margin: 20px 0;
+}
+
+.share-content {
+  flex: 1;
+}
+
+.share-content blockquote {
+  font-size: 18px;
+  line-height: 1.6;
+  color: #333;
+  border-left: 4px solid #4285f4;
+  padding-left: 15px;
+  margin: 0 0 20px 0;
+}
+
+.share-source {
+  font-size: 14px;
+  color: #666;
+}
+
+.share-qrcode {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.share-qrcode p {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #666;
+}
+
+@media (min-width: 768px) {
+  .share-card {
+    flex-direction: row;
+  }
+
+  .share-qrcode {
+    margin-top: 0;
+  }
+}
+
+.share-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.download-button {
+  padding: 8px 16px;
+  background-color: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.download-button:hover {
+  background-color: #3367d6;
+}
+
+.download-button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+</style>


### PR DESCRIPTION
> 提示：组件有一些可以被 [primevue](https://primevue.org/vite) 替代但是我搞忘了，所以还有待修改（以及添加说明文本），先放一个pr在这里，用来进一步讨论 #211 

本PR实现了分享卡片功能的全面优化，主要包括：
- 复制到剪贴板功能/下载到本地
- QR码指向当前文章
- 多种颜色主题选项 （包括 VIS 中的橙色和天青色）
- 3倍分辨率的高清图片导出

原本采用 html2canvas，实际采用 dom-to-image-more 

使用指南：

1.选择对应文字会在正上方显示 **复制文字** 和 **分享** 两个按钮。

![image](https://github.com/user-attachments/assets/f588644d-e6c7-4563-a539-67f18c75edbd)

2.点击**复制**复制文字，点击分享弹出卡片预览框
- 切换主题色
- 添加到剪切栏和下载png到本地
- 二维码预览等

![image](https://github.com/user-attachments/assets/e82f1fef-45c7-431d-9d3e-39f1e7d439ac)


测试： Windows 10, MS Edge 与 Google Chrome